### PR TITLE
ensure temp file is deleted on process exit

### DIFF
--- a/src/gulp-jsdoc.js
+++ b/src/gulp-jsdoc.js
@@ -8,6 +8,9 @@ let os = require('os').type();
 
 let debug = require('debug')('gulp-jsdoc3');
 
+// tmp is not deleting the file by default (https://github.com/raszi/node-tmp/issues/266)
+tmp.setGracefulCleanup();
+
 /**
  * @callback gulpDoneCallback
  */


### PR DESCRIPTION
Large projects fill up the /tmp disk due 'tmp' not cleaning up correctly.
The documentation is misleading see: 
- https://github.com/raszi/node-tmp/issues/266 
- https://github.com/raszi/node-tmp#graceful-cleanup